### PR TITLE
Rewrite of Barrier collision method.

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -17,7 +17,7 @@ Q.Sprite.extend("Player", {
         // hit.sprite is called everytime the player collides with a sprite
         this.on("hit.sprite", function (collision) {
             if (collision.obj.isA("Hazard")) {
-                Q.stageScene("endGame", 1, { label: "Game Over" });
+                Q.stageScene("endGame", window.textboxScene, { label: "Game Over" });
                 this.destroy();
             }
             // Check the collision, if it's the Tower, you win!

--- a/src/puzzle.js
+++ b/src/puzzle.js
@@ -18,41 +18,39 @@ Q.Sprite.extend("Item", {
 
 // Create the Enemy class to add in some baddies
 Q.Sprite.extend("Barrier",{
-  init: function(p) {
-    this._super(p, { sheet: 'tower', keys: ["a-key"] });
-
-    // Listen for a sprite collision, if it's the player,
-    // end the game unless the enemy is hit on top
-    this.on("hit.sprite",function(collision) {
-      if(collision.obj.isA("Player")) {
-        Q.stage().pause()
-
-        // Check if Player has all the items needed to pass Barrier
-        hasAll = true
-        keyIndexes = this.p.keys
-
-        for (i = 0; i < keyIndexes.length; i++) {
-          var keyIndex = collision.obj.p.keys.indexOf(keyIndexes[i])
-          if (keyIndex == -1) {
-            Q.stageScene("textbox", window.textboxScene, { label: this.p.badmsg})
-            hasAll = false
-            break
-          } else {
-            keyIndexes[i] = keyIndex
-          }
-        }
-
-        if (hasAll) {
-          for (i = 0; i < keyIndexes.length; i++) {
-            collision.obj.p.keys.splice(keyIndexes[i], 1) // Remove key from Player.keys
-          }
-            Q.stageScene("textbox", window.textboxScene, { label: this.p.okmsg})
-            this.destroy()
-        }
-      }
-    });
-  }
-});
+    init: function(p) {
+	this._super(p, { sheet: 'tower',
+			 keys: ["a-key"],
+			 badmsg: "I'm sorry to see you cry.",
+			 okmsg: "You're the best dude."
+		       })
+	
+	// Listen for a sprite collision, if it's the player,
+	// end the game unless the enemy is hit on top
+	this.on("hit.sprite",function(collision) {
+	    if(collision.obj.isA("Player")) {
+		// If Player is missing any keys show badmsg and return.
+		console.log("Checking for player keys.")
+		for (i = 0; i < this.p.keys.length; i++) {
+		    index = collision.obj.p.keys.indexOf(this.p.keys[i])
+		    if (index == -1) {
+			Q.stage().pause()
+			Q.stageScene("textbox", window.textboxScene, { label: this.p.badmsg })
+			return
+		    }
+		}
+		console.log("Player has all keys.")
+		// Player has all keys. Remove from player inventory.
+		for (i = 0; i < this.p.keys.length; i++) {
+		    Q.stage().pause()
+		    Q.stageScene("textbox", window.textboxScene, { label: this.p.okmsg })
+		    collision.obj.p.keys.splice(this.p.keys[i], 1)
+		    this.destroy()
+		}
+	    }
+	})
+    }
+})
 
 Q.Sprite.extend("Goal", {
     init: function(p) {


### PR DESCRIPTION
I took a quick look at our problem again (after a solid eight hours sleep), and found the core issue. We had planned to give barriers two message strings: one if all required keys were held by the player, and one if the player was missing keys. Well it doesn't look like we ever got that idea into code. I added `badmsg` and `okmsg` to the Barrier constructor to fix our crashing problem.

**[Edit]**
The `badmsg` and `okmsg` params are default values. They can be overwritten in `objects.json`.
